### PR TITLE
feat: support configuring multiple validators for each network

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,28 +11,42 @@ This is a Prometheus exporter for Solana validators that supports monitoring mul
 
 ## Setup
 
-1.  **Create a configuration file.**
+1. **Create a configuration file.**
 
     Copy the `config.example.yaml` to `config.yaml` and update the values:
+
     ```bash
     cp config.example.yaml config.yaml
     ```
+
     Then, edit `config.yaml`:
 
     ### Global Configuration
-    *   `port`: The port the exporter will listen on (e.g., `9090`).
 
-    ### Network RPC URLs (at least one required)
-    *   `rpc_url_mainnet`: The RPC URL for Solana mainnet (e.g., `https://api.mainnet-beta.solana.com`).
-    *   `rpc_url_testnet`: The RPC URL for Solana testnet (optional).
-    *   `rpc_url_devnet`: The RPC URL for Solana devnet (optional).
+    - `port`: The port the exporter will listen on (e.g., `9090`).
 
-    ### Validator Accounts (at least one validator configuration required)
-    *   `mainnet_vote_account` & `mainnet_identity_account`: Your mainnet validator's vote and identity account public keys.
-    *   `testnet_vote_account` & `testnet_identity_account`: Your testnet validator's accounts (optional).
-    *   `devnet_vote_account` & `devnet_identity_account`: Your devnet validator's accounts (optional).
+    ### Networks
 
-    **Note**: The naming convention determines which RPC URL is used (e.g., `mainnet_*` accounts use `rpc_url_mainnet`).
+    Each entry under the `networks` map defines a network to monitor. Example:
+
+    ```yaml
+    networks:
+      solana_mainnet:
+        rpc_url: "https://api.mainnet-beta.solana.com"
+        validators:
+          - vote_address: "YourVoteAccount"
+            identity_address: "YourIdentityAccount"
+        labels:
+          stage: mainnet
+          environment: production
+    ```
+
+    For every network provide:
+    - `rpc_url`: The RPC endpoint for the network.
+    - `validators`: A list of validator objects with `vote_address` and `identity_address` keys.
+    - `labels` _(optional)_: Additional key/value pairs that will be attached to every metric for that network.
+
+    The exporter automatically adds `network` and `vote_account` labels. If you supply a `network` entry inside `labels`, it overrides the default value derived from the config key.
 
 ## Running the Exporter
 
@@ -41,16 +55,19 @@ You have two options to run the exporter: direct build or Docker container.
 ### Option 1: Direct Build
 
 1. **Install Rust** (if not already installed):
+
    ```bash
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
    ```
 
 2. **Build the exporter**:
+
    ```bash
    cargo build --release
    ```
 
 3. **Run the exporter**:
+
    ```bash
    ./target/release/solana-validator-exporter --config-file config.yaml
    ```
@@ -58,11 +75,13 @@ You have two options to run the exporter: direct build or Docker container.
 ### Option 2: Docker Container
 
 1. **Build the Docker image**:
+
    ```bash
    docker build -t solana-validator-exporter -f docker/Dockerfile .
    ```
 
 2. **Run the container**:
+
    ```bash
    docker run -d \
      --name solana-validator-exporter \
@@ -74,6 +93,7 @@ You have two options to run the exporter: direct build or Docker container.
 ## Verifying the Exporter
 
 After running either method, you can verify the exporter is working by accessing the metrics endpoint:
+
 ```bash
 curl http://localhost:9090/metrics
 ```
@@ -82,14 +102,16 @@ The exporter will expose metrics on the port specified in your configuration fil
 
 ## Metrics Labels
 
-All metrics now include the following labels for easy filtering and identification:
-- `network`: The Solana network (mainnet, testnet, or devnet)
-- `vote_account`: The validator's vote account public key
+All metrics include the following labels for easy filtering and identification:
+
+- `network`: Defaults to the network name from the config (override with `labels.network`).
+- `vote_account`: The validator's vote account public key.
+- Any additional key/value pairs provided in the network's `labels` map.
 
 Example metric with labels:
+
 ```
-solana_slot{network="mainnet",vote_account="YourVoteAccount..."} 123456789
-solana_slot{network="testnet",vote_account="YourTestnetVoteAccount..."} 987654321
+solana_slot{network="solana_mainnet",vote_account="YourVoteAccount...",stage="mainnet"} 123456789
 ```
 
-This allows you to create separate Grafana dashboards or alerts for different networks and validators.
+This makes it straightforward to build Grafana dashboards or alerts scoped to specific environments, regions, or clusters.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This is a Prometheus exporter for Solana validators that supports monitoring mul
     - `validators`: A list of validator objects with `vote_address` and `identity_address` keys.
     - `labels` _(optional)_: Additional key/value pairs that will be attached to every metric for that network.
 
-    The exporter automatically adds `network` and `vote_account` labels. If you supply a `network` entry inside `labels`, it overrides the default value derived from the config key.
+    The exporter automatically adds `network` and `vote_account` labels. If you supply a `network` entry inside `labels`, it overrides the default value derived from the config key. Note that you can also set labels for each validator, which overrides the values configured at the network level.
 
 ## Running the Exporter
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,6 +7,9 @@ networks:
     validators:
       - vote_address: "YOUR_MAINNET_VOTE_ACCOUNT_PUBKEY"
         identity_address: "YOUR_MAINNET_IDENTITY_ACCOUNT_PUBKEY"
+        # optional and it overrides the network-level labels
+        labels:
+          description: "SOME_DETAILS_FOR_THIS_VALIDATOR"
       # - vote_address: "OPTIONAL_SECOND_MAINNET_VOTE_ACCOUNT"
       #   identity_address: "OPTIONAL_SECOND_MAINNET_IDENTITY_ACCOUNT"
     labels:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,19 +1,29 @@
-# Global configuration
+# Example configuration demonstrating multiple networks and custom labels.
 port: 9090
 
-# RPC URLs for different networks (at least one required)
-rpc_url_mainnet: "https://api.mainnet-beta.solana.com"
-#rpc_url_testnet: "https://api.testnet.solana.com"  # Optional
-# rpc_url_devnet: "https://api.devnet.solana.com"  # Optional
+networks:
+  solana_mainnet:
+    rpc_url: "https://api.mainnet-beta.solana.com"
+    validators:
+      - vote_address: "YOUR_MAINNET_VOTE_ACCOUNT_PUBKEY"
+        identity_address: "YOUR_MAINNET_IDENTITY_ACCOUNT_PUBKEY"
+      # - vote_address: "OPTIONAL_SECOND_MAINNET_VOTE_ACCOUNT"
+      #   identity_address: "OPTIONAL_SECOND_MAINNET_IDENTITY_ACCOUNT"
+    labels:
+      stage: mainnet
+      environment: production
 
-# Validator accounts for mainnet (at least one validator configuration required)
-mainnet_vote_account: "YOUR_MAINNET_VOTE_ACCOUNT_PUBKEY"
-mainnet_identity_account: "YOUR_MAINNET_IDENTITY_ACCOUNT_PUBKEY"
+  solana_testnet:
+    rpc_url: "https://api.testnet.solana.com"
+    validators:
+      - vote_address: "YOUR_TESTNET_VOTE_ACCOUNT_PUBKEY"
+        identity_address: "YOUR_TESTNET_IDENTITY_ACCOUNT_PUBKEY"
+    # labels: {}
 
-# Optional: Additional validators for other networks
-testnet_vote_account: "YOUR_TESTNET_VOTE_ACCOUNT_PUBKEY"
-testnet_identity_account: "YOUR_TESTNET_IDENTITY_ACCOUNT_PUBKEY"
-
-# Optional: Additional validators for other networks
-devnet_vote_account: "YOUR_DEVNET_VOTE_ACCOUNT_PUBKEY"
-devnet_identity_account: "YOUR_DEVNET_IDENTITY_ACCOUNT_PUBKEY"
+  # solana_devnet:
+  #   rpc_url: "https://api.devnet.solana.com"
+  #   validators:
+  #     - vote_address: "YOUR_DEVNET_VOTE_ACCOUNT_PUBKEY"
+  #       identity_address: "YOUR_DEVNET_IDENTITY_ACCOUNT_PUBKEY"
+  #   labels:
+  #     stage: devnet

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use env_logger::Env;
 use log::info;
 use metrics::exporter::metrics_handler;
 use serde::Deserialize;
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::BufReader;
 use std::sync::Arc;
@@ -23,28 +24,31 @@ struct CliArgs {
 
 #[derive(Debug, Deserialize)]
 struct Config {
-    port: i32,
-    // Network RPC URLs
-    rpc_url_mainnet: Option<String>,
-    rpc_url_testnet: Option<String>,
-    rpc_url_devnet: Option<String>,
-    // Mainnet validator accounts
-    mainnet_vote_account: Option<String>,
-    mainnet_identity_account: Option<String>,
-    // Testnet validator accounts
-    testnet_vote_account: Option<String>,
-    testnet_identity_account: Option<String>,
-    // Devnet validator accounts
-    devnet_vote_account: Option<String>,
-    devnet_identity_account: Option<String>,
+    port: u16,
+    networks: BTreeMap<String, NetworkConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NetworkConfig {
+    rpc_url: String,
+    validators: Vec<NetworkValidator>,
+    #[serde(default)]
+    labels: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NetworkValidator {
+    vote_address: String,
+    identity_address: String,
 }
 
 #[derive(Debug, Clone)]
 struct ValidatorConfig {
-    network: String,
+    network_key: String,
     rpc_url: String,
     vote_account: String,
     identity_account: String,
+    labels: BTreeMap<String, String>,
 }
 
 #[tokio::main]
@@ -60,75 +64,73 @@ async fn main() {
     // Validate configuration and build validator configs
     let mut validator_configs = Vec::new();
 
-    // Check mainnet configuration
-    if let (Some(rpc_url), Some(vote_account), Some(identity_account)) = (
-        &config.rpc_url_mainnet,
-        &config.mainnet_vote_account,
-        &config.mainnet_identity_account,
-    ) {
-        validator_configs.push(ValidatorConfig {
-            network: "mainnet".to_string(),
-            rpc_url: rpc_url.clone(),
-            vote_account: vote_account.clone(),
-            identity_account: identity_account.clone(),
-        });
+    if config.networks.is_empty() {
+        panic!("At least one network must be provided under the `networks` configuration section");
     }
 
-    // Check testnet configuration
-    if let (Some(rpc_url), Some(vote_account), Some(identity_account)) = (
-        &config.rpc_url_testnet,
-        &config.testnet_vote_account,
-        &config.testnet_identity_account,
-    ) {
-        validator_configs.push(ValidatorConfig {
-            network: "testnet".to_string(),
-            rpc_url: rpc_url.clone(),
-            vote_account: vote_account.clone(),
-            identity_account: identity_account.clone(),
-        });
-    }
+    for (network_name, network_config) in &config.networks {
+        for validator in &network_config.validators {
+            let mut labels: BTreeMap<String, String> = network_config
+                .labels
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect();
 
-    // Check devnet configuration
-    if let (Some(rpc_url), Some(vote_account), Some(identity_account)) = (
-        &config.rpc_url_devnet,
-        &config.devnet_vote_account,
-        &config.devnet_identity_account,
-    ) {
-        validator_configs.push(ValidatorConfig {
-            network: "devnet".to_string(),
-            rpc_url: rpc_url.clone(),
-            vote_account: vote_account.clone(),
-            identity_account: identity_account.clone(),
-        });
+            labels
+                .entry("network".to_string())
+                .or_insert(network_name.clone());
+            labels.insert("vote_account".to_string(), validator.vote_address.clone());
+
+            validator_configs.push(ValidatorConfig {
+                network_key: network_name.clone(),
+                rpc_url: network_config.rpc_url.clone(),
+                vote_account: validator.vote_address.clone(),
+                identity_account: validator.identity_address.clone(),
+                labels,
+            });
+        }
     }
 
     if validator_configs.is_empty() {
-        panic!("At least one complete validator configuration (RPC URL, vote account, and identity account) must be provided");
+        panic!("At least one validator must be configured under `networks`");
     }
 
-    info!("Starting exporter with {} validator(s)!", validator_configs.len());
-    
+    info!(
+        "Starting exporter with {} validator(s)!",
+        validator_configs.len()
+    );
+
     // Create shared metrics registry
     let shared_state = Arc::new(Mutex::new(metrics::exporter::AppState {
         registry: prometheus_client::registry::Registry::default(),
     }));
-    
+
     // Create and start metrics collection for each validator
     let mut handles = Vec::new();
     for validator_config in validator_configs {
-        info!("Starting metrics collection for {} validator: {}", 
-              validator_config.network, validator_config.vote_account);
-        
+        let ValidatorConfig {
+            network_key,
+            rpc_url,
+            vote_account,
+            identity_account,
+            labels,
+        } = validator_config;
+
+        info!(
+            "Starting metrics collection for network `{}` validator: {}",
+            &network_key, &vote_account
+        );
+
         let metrics = Arc::new(metrics::exporter::Metrics::new(
-            validator_config.network,
-            validator_config.rpc_url,
-            validator_config.identity_account,
-            validator_config.vote_account,
+            rpc_url,
+            identity_account,
+            vote_account,
+            labels,
         ));
-        
+
         // Initialize metrics in shared registry
         metrics.init_registry(shared_state.clone()).await;
-        
+
         // Start metrics collection loop
         let handle = metrics.clone().run_loop();
         handles.push(handle);
@@ -137,7 +139,7 @@ async fn main() {
     let router = Router::new()
         .route("/metrics", get(metrics_handler))
         .with_state(shared_state.clone());
-    
+
     let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", config.port))
         .await
         .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,8 @@ struct NetworkConfig {
 struct NetworkValidator {
     vote_address: String,
     identity_address: String,
+    #[serde(default)]
+    labels: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone)]
@@ -80,6 +82,9 @@ async fn main() {
                 .entry("network".to_string())
                 .or_insert(network_name.clone());
             labels.insert("vote_account".to_string(), validator.vote_address.clone());
+
+            // Iterate validator.labels and insert into labels, overriding any existing keys
+            labels.extend(validator.labels.clone());
 
             validator_configs.push(ValidatorConfig {
                 network_key: network_name.clone(),

--- a/src/metrics/exporter.rs
+++ b/src/metrics/exporter.rs
@@ -7,66 +7,48 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use log::error;
 use prometheus_client::encoding::text::encode;
-use prometheus_client::encoding::EncodeLabelSet;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::metrics::gauge::Gauge;
 use prometheus_client::registry::Registry;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
-pub struct MethodLabels {
-    pub network: String,
-    pub vote_account: String,
-}
-
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
-pub struct StakeLabels {
-    pub network: String,
-    pub stake_type: String,
-    pub vote_account: String,
-}
-
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
-pub struct BlockLabels {
-    pub network: String,
-    pub block_type: String,
-    pub vote_account: String,
-}
+type MetricLabels = Vec<(String, String)>;
 
 pub struct Metrics {
-    network: String,
     rpc_url: String,
     identity_account: String,
     vote_account: String,
-    pub slot: Family<MethodLabels, Gauge>,
-    pub epoch: Family<MethodLabels, Gauge>,
-    pub epoch_progress: Family<MethodLabels, Gauge>,
-    pub stake: Family<StakeLabels, Gauge>,
-    pub identity_balance: Family<MethodLabels, Gauge>,
-    pub vote_account_balance: Family<MethodLabels, Gauge>,
-    pub blocks: Family<BlockLabels, Gauge>,
-    pub jito_tips: Family<MethodLabels, Gauge>,
-    pub vote_credit_rank: Family<MethodLabels, Gauge>,
-    pub usd_price: Family<MethodLabels, Gauge>,
-    pub epoch_block_rewards: Family<MethodLabels, Gauge>,
-    pub ms_to_next_slot: Family<MethodLabels, Gauge>,
-    pub last_block_rewards: Family<MethodLabels, Gauge>,
-    pub voting_status: Family<MethodLabels, Gauge>,
+    static_labels: Arc<BTreeMap<String, String>>,
+    pub slot: Family<MetricLabels, Gauge>,
+    pub epoch: Family<MetricLabels, Gauge>,
+    pub epoch_progress: Family<MetricLabels, Gauge>,
+    pub stake: Family<MetricLabels, Gauge>,
+    pub identity_balance: Family<MetricLabels, Gauge>,
+    pub vote_account_balance: Family<MetricLabels, Gauge>,
+    pub blocks: Family<MetricLabels, Gauge>,
+    pub jito_tips: Family<MetricLabels, Gauge>,
+    pub vote_credit_rank: Family<MetricLabels, Gauge>,
+    pub usd_price: Family<MetricLabels, Gauge>,
+    pub epoch_block_rewards: Family<MetricLabels, Gauge>,
+    pub ms_to_next_slot: Family<MetricLabels, Gauge>,
+    pub last_block_rewards: Family<MetricLabels, Gauge>,
+    pub voting_status: Family<MetricLabels, Gauge>,
 }
 
 impl Metrics {
     pub fn new(
-        network: String,
         rpc_url: String,
         identity_account: String,
         vote_account: String,
+        labels: BTreeMap<String, String>,
     ) -> Metrics {
         Metrics {
-            network,
             rpc_url,
             identity_account,
             vote_account,
+            static_labels: Arc::new(labels),
             slot: Family::default(),
             epoch: Family::default(),
             epoch_progress: Family::default(),
@@ -371,205 +353,121 @@ impl Metrics {
     }
 
     pub fn set_slot(&self, slot: u64) {
-        self.slot
-            .get_or_create(&MethodLabels {
-                network: self.network.clone(),
-                vote_account: self.vote_account.clone(),
-            })
-            .set(slot as i64);
+        let labels = self.base_label_pairs();
+        self.slot.get_or_create(&labels).set(slot as i64);
     }
 
     pub fn set_epoch(&self, epoch: i64) {
-        self.epoch
-            .get_or_create(&MethodLabels {
-                network: self.network.clone(),
-                vote_account: self.vote_account.clone(),
-            })
-            .set(epoch);
+        let labels = self.base_label_pairs();
+        self.epoch.get_or_create(&labels).set(epoch);
     }
 
     pub fn set_epoch_progress(&self, progress: i64) {
-        self.epoch_progress
-            .get_or_create(&MethodLabels {
-                network: self.network.clone(),
-                vote_account: self.vote_account.clone(),
-            })
-            .set(progress);
+        let labels = self.base_label_pairs();
+        self.epoch_progress.get_or_create(&labels).set(progress);
     }
 
     pub fn set_stake(&self, stake_state: StakeState) {
-        self.stake
-            .get_or_create(&StakeLabels {
-                network: self.network.clone(),
-                stake_type: "activated".to_string(),
-                vote_account: self.vote_account.clone(),
-            })
-            .set(stake_state.activated_stake as i64);
-
-        self.stake
-            .get_or_create(&StakeLabels {
-                network: self.network.clone(),
-                stake_type: "activating".to_string(),
-                vote_account: self.vote_account.clone(),
-            })
-            .set(stake_state.activating_stake as i64);
-
-        self.stake
-            .get_or_create(&StakeLabels {
-                network: self.network.clone(),
-                stake_type: "deactivating".to_string(),
-                vote_account: self.vote_account.clone(),
-            })
-            .set(stake_state.deactivating_stake as i64);
-
-        self.stake
-            .get_or_create(&StakeLabels {
-                network: self.network.clone(),
-                stake_type: "locked".to_string(),
-                vote_account: self.vote_account.clone(),
-            })
-            .set(stake_state.locked_stake as i64);
-
-        self.stake
-            .get_or_create(&StakeLabels {
-                network: self.network.clone(),
-                stake_type: "activated_accounts".to_string(),
-                vote_account: self.vote_account.clone(),
-            })
-            .set(stake_state.activated_stake_accounts as i64);
-
-        self.stake
-            .get_or_create(&StakeLabels {
-                network: self.network.clone(),
-                stake_type: "activating_accounts".to_string(),
-                vote_account: self.vote_account.clone(),
-            })
-            .set(stake_state.activating_stake_accounts as i64);
-
-        self.stake
-            .get_or_create(&StakeLabels {
-                network: self.network.clone(),
-                stake_type: "deactivating_accounts".to_string(),
-                vote_account: self.vote_account.clone(),
-            })
-            .set(stake_state.deactivating_stake_accounts as i64);
+        self.set_stake_metric("activated", stake_state.activated_stake);
+        self.set_stake_metric("activating", stake_state.activating_stake);
+        self.set_stake_metric("deactivating", stake_state.deactivating_stake);
+        self.set_stake_metric("locked", stake_state.locked_stake);
+        self.set_stake_metric("activated_accounts", stake_state.activated_stake_accounts);
+        self.set_stake_metric("activating_accounts", stake_state.activating_stake_accounts);
+        self.set_stake_metric(
+            "deactivating_accounts",
+            stake_state.deactivating_stake_accounts,
+        );
     }
 
     pub fn set_identity_balance(&self, balance: u64) {
+        let labels = self.base_label_pairs();
         self.identity_balance
-            .get_or_create(&MethodLabels {
-                network: self.network.clone(),
-                vote_account: self.vote_account.clone(),
-            })
+            .get_or_create(&labels)
             .set(balance as i64);
     }
 
     pub fn set_vote_account_balance(&self, balance: u64) {
+        let labels = self.base_label_pairs();
         self.vote_account_balance
-            .get_or_create(&MethodLabels {
-                network: self.network.clone(),
-                vote_account: self.vote_account.clone(),
-            })
+            .get_or_create(&labels)
             .set(balance as i64);
     }
 
     pub fn set_block_scheduled(&self, scheduled: u64) {
-        self.blocks
-            .get_or_create(&BlockLabels {
-                network: self.network.clone(),
-                block_type: "scheduled".to_string(),
-                vote_account: self.vote_account.clone(),
-            })
-            .set(scheduled as i64);
+        self.set_block_metric("scheduled", scheduled);
     }
 
     pub fn set_block_production(&self, total: u64, produced: u64, skipped: u64) {
-        self.blocks
-            .get_or_create(&BlockLabels {
-                network: self.network.clone(),
-                block_type: "total".to_string(),
-                vote_account: self.vote_account.clone(),
-            })
-            .set(total as i64);
-
-        self.blocks
-            .get_or_create(&BlockLabels {
-                network: self.network.clone(),
-                block_type: "produced".to_string(),
-                vote_account: self.vote_account.clone(),
-            })
-            .set(produced as i64);
-
-        self.blocks
-            .get_or_create(&BlockLabels {
-                network: self.network.clone(),
-                block_type: "skipped".to_string(),
-                vote_account: self.vote_account.clone(),
-            })
-            .set(skipped as i64);
+        self.set_block_metric("total", total);
+        self.set_block_metric("produced", produced);
+        self.set_block_metric("skipped", skipped);
     }
 
     pub fn set_jito_tips(&self, tips: u64) {
-        self.jito_tips
-            .get_or_create(&MethodLabels {
-                network: self.network.clone(),
-                vote_account: self.vote_account.clone(),
-            })
-            .set(tips as i64);
+        let labels = self.base_label_pairs();
+        self.jito_tips.get_or_create(&labels).set(tips as i64);
     }
 
     pub fn set_vote_credit_rank(&self, rank: u32) {
+        let labels = self.base_label_pairs();
         self.vote_credit_rank
-            .get_or_create(&MethodLabels {
-                network: self.network.clone(),
-                vote_account: self.vote_account.clone(),
-            })
+            .get_or_create(&labels)
             .set(rank as i64);
     }
 
     pub fn set_usd_price(&self, price: i64) {
-        self.usd_price
-            .get_or_create(&MethodLabels {
-                network: self.network.clone(),
-                vote_account: self.vote_account.clone(),
-            })
-            .set(price);
+        let labels = self.base_label_pairs();
+        self.usd_price.get_or_create(&labels).set(price);
     }
 
     pub fn set_epoch_block_rewards(&self, block_rewards: i64) {
+        let labels = self.base_label_pairs();
         self.epoch_block_rewards
-            .get_or_create(&MethodLabels {
-                network: self.network.clone(),
-                vote_account: self.vote_account.clone(),
-            })
+            .get_or_create(&labels)
             .set(block_rewards);
     }
 
     pub fn set_ms_to_next_slot(&self, ms_to_next_slot: i64) {
+        let labels = self.base_label_pairs();
         self.ms_to_next_slot
-            .get_or_create(&MethodLabels {
-                network: self.network.clone(),
-                vote_account: self.vote_account.clone(),
-            })
+            .get_or_create(&labels)
             .set(ms_to_next_slot);
     }
 
     pub fn set_last_block_rewards(&self, last_block_rewards: i64) {
+        let labels = self.base_label_pairs();
         self.last_block_rewards
-            .get_or_create(&MethodLabels {
-                network: self.network.clone(),
-                vote_account: self.vote_account.clone(),
-            })
+            .get_or_create(&labels)
             .set(last_block_rewards);
     }
 
     pub fn set_voting_status(&self, status: i64) {
-        self.voting_status
-            .get_or_create(&MethodLabels {
-                network: self.network.clone(),
-                vote_account: self.vote_account.clone(),
-            })
-            .set(status);
+        let labels = self.base_label_pairs();
+        self.voting_status.get_or_create(&labels).set(status);
+    }
+
+    fn set_stake_metric(&self, stake_type: &str, value: u64) {
+        let labels = self.labels_with("stake_type", stake_type);
+        self.stake.get_or_create(&labels).set(value as i64);
+    }
+
+    fn set_block_metric(&self, block_type: &str, value: u64) {
+        let labels = self.labels_with("block_type", block_type);
+        self.blocks.get_or_create(&labels).set(value as i64);
+    }
+
+    fn base_label_pairs(&self) -> MetricLabels {
+        self.static_labels
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect()
+    }
+
+    fn labels_with(&self, key: &str, value: impl Into<String>) -> MetricLabels {
+        let mut labels = self.base_label_pairs();
+        labels.push((key.to_string(), value.into()));
+        labels
     }
 }
 


### PR DESCRIPTION
With this PR we will be able to run one Solana exporter instance for multiple chains, and each chain we can configure multiple validators as well. An example of the config:

```yaml
# Example configuration demonstrating multiple networks and custom labels.
port: 9090

networks:
  solana_mainnet:
    rpc_url: "https://api.mainnet-beta.solana.com"
    validators:
      - vote_address: "YOUR_MAINNET_VOTE_ACCOUNT_PUBKEY"
        identity_address: "YOUR_MAINNET_IDENTITY_ACCOUNT_PUBKEY"
        # optional and it overrides the network-level labels
        labels:
          description: "SOME_DETAILS_FOR_THIS_VALIDATOR"
      # - vote_address: "OPTIONAL_SECOND_MAINNET_VOTE_ACCOUNT"
      #   identity_address: "OPTIONAL_SECOND_MAINNET_IDENTITY_ACCOUNT"
    labels:
      stage: mainnet
      environment: production

  solana_testnet:
    rpc_url: "https://api.testnet.solana.com"
    validators:
      - vote_address: "YOUR_TESTNET_VOTE_ACCOUNT_PUBKEY"
        identity_address: "YOUR_TESTNET_IDENTITY_ACCOUNT_PUBKEY"
    # labels: {}
```